### PR TITLE
修复索引删除失败的问题； 并添加IndexId的生成函数用于如实体是guid类型的主键，通过该生成函数可去除IndexId的TypeName前缀

### DIFF
--- a/Masuit.LuceneEFCore.SearchEngine/LuceneIndexableBaseEntity.cs
+++ b/Masuit.LuceneEFCore.SearchEngine/LuceneIndexableBaseEntity.cs
@@ -41,7 +41,7 @@ namespace Masuit.LuceneEFCore.SearchEngine
         [NotMapped, JsonIgnore]
         public string IndexId
         {
-            get => GetType().Name + ":" + Id;
+            get => LuceneIndexerOptions.IndexIdGenerator(GetType(), Id);
 
             set
             {
@@ -69,6 +69,25 @@ namespace Masuit.LuceneEFCore.SearchEngine
                 if (propertyValue == null)
                 {
                     continue;
+                }
+
+                {
+                    //1. 该处修复用IndexId去删除索引无效的问题
+                    if (propertyInfo.Name == nameof(LuceneIndexableBaseEntity.IndexId))
+                    {
+                        var filed = new Field(propertyInfo.Name, propertyValue.ToString(), new FieldType()
+                        {
+                            IsStored = true,
+                            IsIndexed = true,
+                            IsTokenized = false
+                        });
+                        doc.Add(filed);
+                        continue;
+                    }
+
+                    //2. 以Id为目标的删除放在其他处： 也利用到了IndexId
+
+
                 }
 
                 var attrs = propertyInfo.GetCustomAttributes<LuceneIndexAttribute>();

--- a/Masuit.LuceneEFCore.SearchEngine/LuceneIndexer.cs
+++ b/Masuit.LuceneEFCore.SearchEngine/LuceneIndexer.cs
@@ -132,7 +132,7 @@ namespace Masuit.LuceneEFCore.SearchEngine
         }
 
         /// <summary>
-        /// 更新索引
+        /// 更新索引-删除索引时仅利用IndexId去删除
         /// </summary>
         /// <param name="changeset">实体</param>
         public void Update(LuceneIndexChangeset changeset)
@@ -144,13 +144,13 @@ namespace Masuit.LuceneEFCore.SearchEngine
                 switch (change.State)
                 {
                     case LuceneIndexState.Removed:
-                        writer.DeleteDocuments(new Term("Id", change.Entity.Id.ToString()));
+                        //writer.DeleteDocuments(new Term("Id", change.Entity.Id.ToString()));
                         writer.DeleteDocuments(new Term("IndexId", change.Entity.IndexId));
                         break;
 
                     case LuceneIndexState.Added:
                     case LuceneIndexState.Updated:
-                        writer.DeleteDocuments(new Term("Id", change.Entity.Id.ToString()));
+                        //writer.DeleteDocuments(new Term("Id", change.Entity.Id.ToString()));
                         writer.DeleteDocuments(new Term("IndexId", change.Entity.IndexId));
                         writer.AddDocument(change.Entity.ToDocument());
                         break;

--- a/Masuit.LuceneEFCore.SearchEngine/LuceneIndexerOptions.cs
+++ b/Masuit.LuceneEFCore.SearchEngine/LuceneIndexerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Masuit.LuceneEFCore.SearchEngine
+﻿using System;
+
+namespace Masuit.LuceneEFCore.SearchEngine
 {
     /// <summary>
     /// 索引器选项
@@ -9,5 +11,11 @@
         /// 索引路径
         /// </summary>
         public string Path { get; set; }
+
+        /// <summary>
+        /// 索引列IndexId的生成函数，(Type EntityType, any IdValue) => string IndexId
+        /// </summary>
+        public static Func<Type, object, string> IndexIdGenerator = (type, id) => $"{type.Name}:{id}";
+
     }
 }


### PR DESCRIPTION
之前的索引失败是由于Id和IndexId的配置，会导致其被分词。 从而导致使用Id或者IndexId删除索引时没有效果。
现在修改IndexId的配置，配置为不分词，并且删除索引时仅利用该字段。从而使得索引能被删除。

添加了额外的IndexId的生成配置，从而让比如以Guid为主键的实体，生成的IndexId可以简单备配置为Guid.ToString()

大佬请审核，目前看来WebSearchDemo 和我自己的工程都是正常可用的。暂时没有发现该改动的不良影响